### PR TITLE
Add make run

### DIFF
--- a/atividade1/Makefile
+++ b/atividade1/Makefile
@@ -39,4 +39,8 @@ rebuild: clean $(BIN_DIR)/$(TARGET)
 # Definir "all" como a regra padrão
 all: $(BIN_DIR)/$(TARGET)
 
-.PHONY: all clean rebuild
+# Executa o programa
+run: $(BIN_DIR)/$(TARGET)
+	./$(BIN_DIR)/$(TARGET)
+
+.PHONY: all clean rebuild run


### PR DESCRIPTION
The default Makefile command directs all binaries to a `bin/` directory, so to run the program it was always necessary to access this directory. This PR adds the `run` command to run the application directly.